### PR TITLE
Do not attempt to match newline characters

### DIFF
--- a/grammars/frege autocompletion hint.cson
+++ b/grammars/frege autocompletion hint.cson
@@ -86,7 +86,7 @@
           {
             'name': 'comment.line.double-dash.haddock.frege'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.frege'
@@ -102,7 +102,7 @@
           {
             'name': 'comment.line.double-dash.frege'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.frege'
@@ -710,7 +710,7 @@
       {
         'name': 'meta.preprocessor.c.frege'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/frege message hint.cson
+++ b/grammars/frege message hint.cson
@@ -108,7 +108,7 @@
           {
             'name': 'comment.line.double-dash.haddock.frege'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.frege'
@@ -124,7 +124,7 @@
           {
             'name': 'comment.line.double-dash.frege'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.frege'
@@ -732,7 +732,7 @@
       {
         'name': 'meta.preprocessor.c.frege'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/frege type hint.cson
+++ b/grammars/frege type hint.cson
@@ -83,7 +83,7 @@
           {
             'name': 'comment.line.double-dash.haddock.frege'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.frege'
@@ -99,7 +99,7 @@
           {
             'name': 'comment.line.double-dash.frege'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.frege'
@@ -707,7 +707,7 @@
       {
         'name': 'meta.preprocessor.c.frege'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/grammars/frege.cson
+++ b/grammars/frege.cson
@@ -82,7 +82,7 @@
           {
             'name': 'comment.line.double-dash.haddock.frege'
             'begin': '(--+)\\s+([|^])'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '1':
                 'name': 'punctuation.definition.comment.frege'
@@ -98,7 +98,7 @@
           {
             'name': 'comment.line.double-dash.frege'
             'begin': '--'
-            'end': '\\n'
+            'end': '$'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.frege'
@@ -706,7 +706,7 @@
       {
         'name': 'meta.preprocessor.c.frege'
         'begin': '^(?=#)'
-        'end': '(?<!\\\\)(?=\\n)'
+        'end': '(?<!\\\\)(?=$)'
         'patterns': [
           {
             'include': 'source.c'

--- a/spec/frege-record-spec.coffee
+++ b/spec/frege-record-spec.coffee
@@ -555,17 +555,6 @@ describe 'Record', ->
                   "meta.type-signature.frege",
                   "comment.line.double-dash.frege"
                 ]
-              },
-              {
-                "value": "",
-                "scopes": [
-                  "source.frege",
-                  "meta.declaration.type.data.frege",
-                  "meta.declaration.type.data.record.block.frege",
-                  "meta.record-field.type-declaration.frege",
-                  "meta.type-signature.frege",
-                  "comment.line.double-dash.frege"
-                ]
               }
             ],
             [
@@ -593,17 +582,6 @@ describe 'Record', ->
               },
               {
                 "value": " model :: String, -- commented field",
-                "scopes": [
-                  "source.frege",
-                  "meta.declaration.type.data.frege",
-                  "meta.declaration.type.data.record.block.frege",
-                  "meta.record-field.type-declaration.frege",
-                  "meta.type-signature.frege",
-                  "comment.line.double-dash.frege"
-                ]
-              },
-              {
-                "value": "",
                 "scopes": [
                   "source.frege",
                   "meta.declaration.type.data.frege",
@@ -700,17 +678,6 @@ describe 'Record', ->
               },
               {
                 "value": " another comment",
-                "scopes": [
-                  "source.frege",
-                  "meta.declaration.type.data.frege",
-                  "meta.declaration.type.data.record.block.frege",
-                  "meta.record-field.type-declaration.frege",
-                  "meta.type-signature.frege",
-                  "comment.line.double-dash.frege"
-                ]
-              },
-              {
-                "value": "",
                 "scopes": [
                   "source.frege",
                   "meta.declaration.type.data.frege",
@@ -847,15 +814,6 @@ describe 'Record', ->
           },
           {
             "value": " company :: String",
-            "scopes": [
-              "source.frege",
-              "meta.declaration.type.data.frege",
-              "meta.declaration.type.data.record.block.frege",
-              "comment.line.double-dash.frege"
-            ]
-          },
-          {
-            "value": "",
             "scopes": [
               "source.frege",
               "meta.declaration.type.data.frege",

--- a/spec/language-frege-spec.coffee
+++ b/spec/language-frege-spec.coffee
@@ -479,10 +479,9 @@ describe "Language-Frege", ->
   describe "regression test for comments after module name in imports", ->
     it "parses comments after module names", ->
       g = grammarExpect grammar, 'import Module -- comment'
-      g.toHaveTokens [['import', ' ', 'Module', ' ', '--', ' comment', '']]
+      g.toHaveTokens [['import', ' ', 'Module', ' ', '--', ' comment']]
       g.toHaveScopes [['source.frege', 'meta.import.frege']]
       g.tokenToHaveScopes [[[2, ['support.other.module.frege']]
                             [4, ['comment.line.double-dash.frege', 'punctuation.definition.comment.frege']]
                             [5, ['comment.line.double-dash.frege']]
-                            [6, ['comment.line.double-dash.frege']]
                             ]]

--- a/src/include/repository.coffee
+++ b/src/include/repository.coffee
@@ -36,7 +36,7 @@ module.exports=
         patterns: [
             name: 'comment.line.double-dash.haddock.frege'
             begin: /(--+)\s+([|^])/
-            end: /\n/
+            end: /$/
             beginCaptures:
               1: name: 'punctuation.definition.comment.frege'
               2: name: 'punctuation.definition.comment.haddock.frege'
@@ -52,7 +52,7 @@ module.exports=
         patterns: [
             name: 'comment.line.double-dash.frege'
             begin: /--/
-            end: /\n/
+            end: /$/
             beginCaptures:
               0: name: 'punctuation.definition.comment.frege'
         ]
@@ -398,7 +398,7 @@ module.exports=
   c_preprocessor:
     name: 'meta.preprocessor.c'
     begin: /{maybeBirdTrack}(?=#)/
-    end: '(?<!\\\\)(?=\\n)'
+    end: '(?<!\\\\)(?=$)'
     patterns: [
       include: 'source.c'
     ]


### PR DESCRIPTION
This PR replaces all \\n end matches with $. The two are nearly identical, with the only difference being that $ does not create a zero-width match at the end of the line.  These changes are mainly required due to atom/first-mate#100, as newlines are no longer added to the last line of the file. Therefore, this change is simply a backwards-compatible change to ensure that language-frege continues working as before on Atom 1.22+.

I hope I did the whole grammar generation correctly!

/cc @Ingramz

Refs atom/atom#15729